### PR TITLE
TST-840 — Fully editable footer with BCAPI feature

### DIFF
--- a/templates/components/common/footer.html
+++ b/templates/components/common/footer.html
@@ -43,35 +43,15 @@
                 </nav>
                 <nav class="footer-info-four-col tst-accordion-item" data-section-type="footer-about-us">
                     <h3 class="footer-info-heading">{{lang 'footer.about_us'}}</h3>
-                    <ul class="footer-info-list tst-accordion-body">
-                        {{#each pages}}
-                            <li>
-                                <a href="{{url}}">{{name}}</a>
-                            </li>
-                        {{/each}}
-                    </ul>
+                    <div id="bcapi_footer_about_links"></div>
                 </nav>
                 <nav class="footer-info-four-col tst-accordion-item" data-section-type="footer-brands">
                     <h3 class="footer-info-heading">{{lang 'footer.support'}}</h3><i class="arrow down"></i>
-                    <ul class="footer-info-list tst-accordion-body">
-                        <li>
-                            <a href="/contact-us">Contact Us</a>
-                        </li>
-                        <li>
-                            <a href="/faq">FAQ</a>
-                        </li>
-                    </ul>
+                    <div id="bcapi_footer_support_links"></div>
                 </nav>
                 <nav class="footer-info-four-col tst-accordion-item" data-section-type="footer-brands">
                     <h3 class="footer-info-heading">{{lang 'footer.helpful_links'}}</h3>
-                    <ul class="footer-info-list tst-accordion-body">
-                        <li>
-                            <a href="/#">Link to TS Central</a>
-                        </li>
-                        <li>
-                            <a href="/#">Code of Conduct</a>
-                        </li>
-                    </ul>
+                    <div id="bcapi_footer_helpful_links"></div>
                 </nav>
             </section>
             <section class="footer-info mobile">
@@ -154,3 +134,4 @@
         {{{region name="ssl_site_seal--global"}}}
     </div>
 </footer>
+{{> components/consultant-store/bcapi-loader }}

--- a/templates/components/consultant-store/bcapi-loader.html
+++ b/templates/components/consultant-store/bcapi-loader.html
@@ -1,0 +1,38 @@
+<script>
+    /**
+     * This component looks for all layers whose IDs begin with bcapi_ and tries to
+     * make an AJAX call to a BigCommerce page with the same URL Key.
+     * If the content is found, it will load it into the layer.
+     *
+     *
+     * This feature provides the ability of potentially allowing the client to make changes
+     * to any location of the site, as long as a bcapi_ div is placed there.
+     */
+
+    /**
+     * @param resultContainer
+     */
+    function loadBcApi(resultContainer) {
+        var xmlhttp = new XMLHttpRequest();
+        xmlhttp.onreadystatechange = function() {
+            if (xmlhttp.readyState == XMLHttpRequest.DONE) {
+                if (xmlhttp.status == 200) {
+                    document.getElementById(resultContainer).innerHTML = xmlhttp.responseText;
+                }
+                else {
+                    console(`Could not load content for ${resultContainer}`);
+                }
+            }
+        };
+
+        const requestUrl = '/' + resultContainer + '/';
+
+        xmlhttp.open("GET", requestUrl, true);
+        xmlhttp.send();
+    }
+    const bcapiDivs = document.querySelectorAll('div[id^="bcapi_"]')
+
+    bcapiDivs.forEach((element, index) => {
+        loadBcApi(element.id);
+    });
+</script>

--- a/templates/pages/custom/page/empty.html
+++ b/templates/pages/custom/page/empty.html
@@ -1,0 +1,1 @@
+{{{page.content}}}


### PR DESCRIPTION
This feature provides the ability of potentially allowing the client to make changes to any location of the site, as long as a bcapi_ div is placed there. Currently implemented only for the footer links, but can be easily extended by following the instructions at templates/components/consultant-store/bcapi-loader.html
