### PR TITLE
Fix email address for customer service on account order page

### DIFF
--- a/config.json
+++ b/config.json
@@ -372,7 +372,8 @@
     "subscription_management": {
       "enabled": true,
       "api_url": "https://qa1-subscription.api.tastefullysimple.com/4"
-    }
+    },
+    "ts_help_email": "help@tastefullysimple.com"
   },
   "read_only_files": [
     "/assets/scss/components/citadel",


### PR DESCRIPTION
This PR fixes the TS customer service email which was not showing up on Account > Orders page.