### PR TITLE
TST-951 — Fix subscription modal not closing on PDP page

### DIFF
--- a/assets/js/theme/global/custom/session-manager.js
+++ b/assets/js/theme/global/custom/session-manager.js
@@ -10,6 +10,14 @@ let intervalId = null;
  */
 function verifyTimeout(loginModal, content) {
     if (new Date().getTime() > window.localStorage.getItem('consultant-timeout')) {
+        const $element = $(document);
+        $element.foundation({
+            reveal: {
+                close_on_background_click: false,
+                close_on_esc: false,
+                bg_class: 'modal-background-solid',
+            },
+        });
         loginModal.open();
         loginModal.updateContent(content);
         $('#sso_login_message').hide();

--- a/assets/js/theme/global/custom/subscription-manager.js
+++ b/assets/js/theme/global/custom/subscription-manager.js
@@ -109,9 +109,17 @@ function isAutoshipEnabled(productId) {
                 // This product is Autoship Eligible. Show  Widget Version 2
                 window.subscriptionManager.version = 'future';
             }
+            const $element = $(document);
+            $element.foundation({
+                reveal: {
+                    close_on_background_click: true,
+                    close_on_esc: true,
+                    bg_class: 'modal-background',
+                },
+            });
             // Display Button and message
             $(`#subscription--container-${window.subscriptionManager.version}`).show();
-            const subscriptionModal = modalFactory(`#subscriptionManager--${window.subscriptionManager.version}`)[0];
+            const subscriptionModal = modalFactory(`#subscriptionManager--${window.subscriptionManager.version}`, { $context: $element })[0];
             // Show Add to Next Delivery (Widget Version 1)
             const $subscriptionManagerTrigger = $(`#subscriptionManager--trigger-${window.subscriptionManager.version}`);
             $subscriptionManagerTrigger.on('click', () => {


### PR DESCRIPTION
This is a bug with the Modal Factory where the modal options are set globally when you set just one modal. Because of this, the close on background and close on esc options need to be always set BEFORE the modal is open, rather than setting them on the modal creation.